### PR TITLE
setUserAttributes 메서드를 access_globals에 추가

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -2,9 +2,11 @@ homepage: "https://www.flarelane.com"
 documentation: "https://docs.flarelane.co.kr"
 versions:
   # Latest version
+  - sha: 87fc605d2cd8a294f63ae199e526c2e57e1f36c3
+    changeNotes: Add access global permission for setUserAttributes
+  # Older versions
   - sha: c660a7aff062d0a2c5a7e1be1363b3af3f7f4c90
     changeNotes: Add Data table in displayInApp method
-  # Older versions
   - sha: 577732ca077dec7b2c8ef040be5b2aebb6576a66
     changeNotes: Add set user attributes method
   - sha: 04d6765cc896a233ecce1012562e5c1f1be7a43b

--- a/template.tpl
+++ b/template.tpl
@@ -575,6 +575,45 @@ ___WEB_PERMISSIONS___
                 "mapValue": [
                   {
                     "type": 1,
+                    "string": "FlareLane.setUserAttributes"
+                  },
+                  {
+                    "type": 8,
+                    "boolean": true
+                  },
+                  {
+                    "type": 8,
+                    "boolean": false
+                  },
+                  {
+                    "type": 8,
+                    "boolean": true
+                  }
+                ]
+              },
+              {
+                "type": 3,
+                "mapKey": [
+                  {
+                    "type": 1,
+                    "string": "key"
+                  },
+                  {
+                    "type": 1,
+                    "string": "read"
+                  },
+                  {
+                    "type": 1,
+                    "string": "write"
+                  },
+                  {
+                    "type": 1,
+                    "string": "execute"
+                  }
+                ],
+                "mapValue": [
+                  {
+                    "type": 1,
                     "string": "FlareLane.setUserId"
                   },
                   {


### PR DESCRIPTION
setUserAttributes 메서드가 access_globals 설정에 포함되어 있지 않아 메서드가 권한 문제로 실행되지 않던 문제를 수정합니다.

<img width="938" height="267" alt="image" src="https://github.com/user-attachments/assets/8889b1e6-60a0-4891-8a2d-4a38b41d2f2f" />
<img width="3338" height="328" alt="image" src="https://github.com/user-attachments/assets/52a101d9-d0f8-473c-a0e3-d4950537d914" />
